### PR TITLE
Update Mavis, enable C++23 support, add uarch JSON dumping to isa_dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ PROJECT(mavis_tools CXX)
 
 cmake_minimum_required (VERSION 3.15)
 
-set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD 23)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package (Boost 1.74.0 REQUIRED COMPONENTS program_options json)
@@ -34,6 +34,7 @@ endif()
 
 include(std_filesystem)
 
+set(MAVIS_CXX_STANDARD 23)
 add_subdirectory(mavis)
 
 add_subdirectory(tools)

--- a/include/command_line_param.hpp
+++ b/include/command_line_param.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <vector>
+#include <boost/program_options.hpp>
+
+#include "mavis_path.hpp"
+
+namespace mavis_tools
+{
+    // Gets a scalar command line parameter value from boost::program_options::variables_map
+    template <typename ValueType> struct CommandLineParamGetter
+    {
+        template <typename FinalType = ValueType>
+        static constexpr FinalType getValue(const std::string_view name,
+                                            const boost::program_options::variables_map & vm)
+        {
+            const auto value = vm[std::string(name)].as<ValueType>();
+
+            if constexpr (std::is_same_v<ValueType, FinalType>)
+            {
+                return value;
+            }
+            else
+            {
+                return FinalType(value);
+            }
+        }
+    };
+
+    // Gets a vector command line parameter value from boost::program_options::variables_map
+    template <typename ValueType> struct CommandLineParamGetter<std::vector<ValueType>>
+    {
+        template <typename FinalType = std::vector<ValueType>>
+        static constexpr FinalType getValue(const std::string_view name,
+                                            const boost::program_options::variables_map & vm)
+        {
+            const auto value = vm[std::string(name)].as<std::vector<ValueType>>();
+
+            if constexpr (std::is_same_v<std::vector<ValueType>, FinalType>)
+            {
+                return value;
+            }
+            else
+            {
+                return FinalType(value.begin(), value.end());
+            }
+        }
+    };
+
+    // Helper class for defining and getting command line parameters
+    template <typename ValueType> class CommandLineParam
+    {
+      private:
+        const std::string_view name_;
+        const char short_param_;
+        const bool multitoken_;
+        const std::string_view help_msg_;
+
+      public:
+        consteval CommandLineParam(const std::string_view name, const std::string_view help_msg) :
+            name_(name),
+            short_param_('\0'),
+            multitoken_(false),
+            help_msg_(help_msg)
+        {
+        }
+
+        consteval CommandLineParam(const std::string_view name, const char short_param,
+                                   const std::string_view help_msg) :
+            name_(name),
+            short_param_(short_param),
+            multitoken_(false),
+            help_msg_(help_msg)
+        {
+        }
+
+        consteval CommandLineParam(const std::string_view name, const bool multitoken,
+                                   const std::string_view help_msg) :
+            name_(name),
+            short_param_('\0'),
+            multitoken_(multitoken),
+            help_msg_(help_msg)
+        {
+        }
+
+        consteval CommandLineParam(const std::string_view name, const char short_param,
+                                   const bool multitoken, const std::string_view help_msg) :
+            name_(name),
+            short_param_(short_param),
+            multitoken_(multitoken),
+            help_msg_(help_msg)
+        {
+        }
+
+        constexpr bool exists(const boost::program_options::variables_map & vm) const
+        {
+            return vm.count(std::string(name_)) != 0;
+        }
+
+        constexpr void addOption(boost::program_options::options_description & args) const
+        {
+            std::string param_str{name_};
+            if (short_param_)
+            {
+                param_str += ',';
+                param_str += short_param_;
+            }
+
+            auto value = boost::program_options::value<ValueType>()->value_name(std::string(name_));
+
+            if (multitoken_)
+            {
+                value->multitoken();
+            }
+
+            args.add_options()(param_str.c_str(), value, help_msg_.data());
+        }
+
+        template <typename FinalType = ValueType>
+        constexpr FinalType getValue(const boost::program_options::variables_map & vm) const
+        {
+            if (exists(vm))
+            {
+                return CommandLineParamGetter<ValueType>::template getValue<FinalType>(name_, vm);
+            }
+
+            return {};
+        }
+    };
+
+    inline boost::program_options::options_description getDefaultOptionalArgs(fs::path & mavis_path)
+    {
+        boost::program_options::options_description optional_args("Optional arguments");
+        optional_args.add_options()("help,h", "print this help message")(
+            "mavis,m",
+            boost::program_options::value<fs::path>(&mavis_path)
+                ->default_value(mavis_tools::getMavisPath())
+                ->value_name("path"),
+            "path to mavis");
+        return optional_args;
+    }
+} // namespace mavis_tools

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string_view>
+
+namespace mavis_tools
+{
+    // JSON key for mnemonics
+    static inline constexpr std::string_view MNEMONIC_KEY{"mnemonic"};
+} // namespace mavis_tools

--- a/include/json_key.hpp
+++ b/include/json_key.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <boost/json.hpp>
+#include <iomanip>
+#include <istream>
+#include <ostream>
+#include <string>
+
+namespace mavis_tools
+{
+    // Holds a JSON key name and calculates the optimal width for a column-formatted view
+    class JSONKey
+    {
+      private:
+        static constexpr uint32_t COLUMN_PADDING_ = 4;
+
+        std::string key_;
+        size_t column_width_{key_.size() + COLUMN_PADDING_};
+
+        void updateWidth_(const size_t new_width)
+        {
+            column_width_ = std::max(column_width_, new_width + COLUMN_PADDING_);
+        }
+
+        void formatColumn_(std::ostream & os) const { os << std::left << std::setw(column_width_); }
+
+      public:
+        JSONKey() = default;
+
+        explicit JSONKey(const std::string_view key) : key_(key) {}
+
+        const std::string & getKey() const { return key_; }
+
+        void updateWidth(const boost::json::string & str) { updateWidth_(str.size()); }
+
+        void updateWidth(const std::string & str) { updateWidth_(str.size()); }
+
+        void updateWidth(const boost::json::value & val)
+        {
+            if (val.is_string())
+            {
+                updateWidth(val.as_string());
+            }
+            else
+            {
+                updateWidth(boost::json::serialize(val));
+            }
+        }
+
+        void formatColumn(std::ostream & os, const boost::json::value & val) const
+        {
+            if (val.is_string())
+            {
+                formatColumn(os, val.as_string());
+            }
+            else
+            {
+                formatColumn_(os);
+                os << val;
+            }
+        }
+
+        void formatColumn(std::ostream & os, const boost::json::string & str) const
+        {
+            formatColumn_(os);
+            os << str.c_str();
+        }
+
+        void formatColumn(std::ostream & os, const std::string & str) const
+        {
+            formatColumn_(os);
+            os << str;
+        }
+
+        friend inline std::istream & operator>>(std::istream & is, JSONKey & key_info)
+        {
+            is >> key_info.key_;
+            key_info.updateWidth(key_info.key_);
+            return is;
+        }
+
+        friend inline std::ostream & operator<<(std::ostream & os, const JSONKey & key_info)
+        {
+            key_info.formatColumn(os, key_info.key_);
+            return os;
+        }
+    };
+} // namespace mavis_tools

--- a/include/mavis_path.hpp
+++ b/include/mavis_path.hpp
@@ -11,128 +11,134 @@
 
 #include "filesystem.hpp"
 
-class CouldNotFindExecutableException : public std::exception
+namespace mavis_tools
 {
-  public:
-    const char* what() const noexcept override { return "Failed to get path to exe"; }
-};
-
-/**
- * Gets the path to the current executable
- */
-inline fs::path getExecutablePath()
-{
-#ifdef __APPLE__ // OSX
-    static constexpr uint32_t DEFAULT_BUF_SIZE = 256;
-    uint32_t buf_size = DEFAULT_BUF_SIZE;
-    std::unique_ptr<char[]> path_buf = std::make_unique<char[]>(DEFAULT_BUF_SIZE);
-
-    if (_NSGetExecutablePath(path_buf.get(), &buf_size) != 0)
+    class CouldNotFindExecutableException : public std::exception
     {
-        // path_buf was too small, so reallocate and try again
-        path_buf = std::make_unique<char[]>(buf_size);
+      public:
+        const char* what() const noexcept override { return "Failed to get path to exe"; }
+    };
+
+    /**
+     * Gets the path to the current executable
+     */
+    inline fs::path getExecutablePath()
+    {
+#ifdef __APPLE__ // OSX
+        static constexpr uint32_t DEFAULT_BUF_SIZE = 256;
+        uint32_t buf_size = DEFAULT_BUF_SIZE;
+        std::unique_ptr<char[]> path_buf = std::make_unique<char[]>(DEFAULT_BUF_SIZE);
+
         if (_NSGetExecutablePath(path_buf.get(), &buf_size) != 0)
         {
-            throw CouldNotFindExecutableException();
+            // path_buf was too small, so reallocate and try again
+            path_buf = std::make_unique<char[]>(buf_size);
+            if (_NSGetExecutablePath(path_buf.get(), &buf_size) != 0)
+            {
+                throw CouldNotFindExecutableException();
+            }
         }
-    }
 
-    const char* const relative_path = path_buf.get();
+        const char* const relative_path = path_buf.get();
 
-    // fs::read_symlink will throw an exception if it isn't a symlink, so check first
-    if (!fs::is_symlink(relative_path))
-    {
-        return fs::canonical(relative_path);
-    }
+        // fs::read_symlink will throw an exception if it isn't a symlink, so check first
+        if (!fs::is_symlink(relative_path))
+        {
+            return fs::canonical(relative_path);
+        }
 #else // Linux
-    static const char* const relative_path = "/proc/self/exe"; // always a symlink
+        static const char* const relative_path = "/proc/self/exe"; // always a symlink
 #endif
-    return fs::canonical(fs::read_symlink(relative_path));
-}
-
-class CouldNotFindMavisException : public std::exception
-{
-  public:
-    const char* what() const noexcept override
-    {
-        return "Could not find Mavis JSON files anywhere. Please define the MAVIS_PATH environment "
-               "variable to point to your Mavis checkout.";
-    }
-};
-
-/**
- * Gets a default path to Mavis
- */
-inline std::string getMavisPath()
-{
-    static constexpr std::string_view DEFAULT_RELATIVE_JSON_PATH_ =
-        "../../../mavis"; /**< Default path to Mavis JSON files if building locally*/
-
-    const auto mavis_path_env = getenv("MAVIS_PATH");
-    if (mavis_path_env && fs::exists(mavis_path_env))
-    {
-        return std::string(mavis_path_env);
+        return fs::canonical(fs::read_symlink(relative_path));
     }
 
-    const auto exe_dir = getExecutablePath().parent_path();
-
-    const auto relative_path = exe_dir / DEFAULT_RELATIVE_JSON_PATH_;
-
-    if (fs::exists(relative_path))
+    class CouldNotFindMavisException : public std::exception
     {
-        return relative_path;
-    }
+      public:
+        const char* what() const noexcept override
+        {
+            return "Could not find Mavis JSON files anywhere. Please define the MAVIS_PATH "
+                   "environment "
+                   "variable to point to your Mavis checkout.";
+        }
+    };
 
-    static constexpr std::string_view SHARE_RELATIVE_JSON_PATH_ = "../share/mavis_tools/mavis";
-
-    const auto share_relative_path = exe_dir / SHARE_RELATIVE_JSON_PATH_;
-
-    if (fs::exists(share_relative_path))
+    /**
+     * Gets a default path to Mavis
+     */
+    inline fs::path getMavisPath()
     {
-        return share_relative_path;
-    }
+        static constexpr std::string_view DEFAULT_RELATIVE_JSON_PATH_ =
+            "../../../mavis"; /**< Default path to Mavis JSON files if building locally*/
 
-    static constexpr std::string_view SHARE_GLOBAL_JSON_PATH_ = "/usr/share/mavis_tools/mavis";
+        const auto mavis_path_env = getenv("MAVIS_PATH");
+        if (mavis_path_env && fs::exists(mavis_path_env))
+        {
+            return fs::path(mavis_path_env);
+        }
 
-    if (fs::exists(SHARE_GLOBAL_JSON_PATH_))
-    {
-        return std::string(SHARE_GLOBAL_JSON_PATH_);
-    }
+        const auto exe_dir = getExecutablePath().parent_path();
 
-    // Check for an existing stf_tools install if there isn't a global mavis_tools install
-    static constexpr std::string_view STF_SHARE_RELATIVE_JSON_PATH_ = "../share/stf_tools/mavis";
+        const auto relative_path = exe_dir / DEFAULT_RELATIVE_JSON_PATH_;
 
-    const auto stf_share_relative_path = exe_dir / STF_SHARE_RELATIVE_JSON_PATH_;
+        if (fs::exists(relative_path))
+        {
+            return relative_path;
+        }
 
-    if (fs::exists(stf_share_relative_path))
-    {
-        return share_relative_path;
-    }
+        static constexpr std::string_view SHARE_RELATIVE_JSON_PATH_ = "../share/mavis_tools/mavis";
 
-    static constexpr std::string_view STF_SHARE_GLOBAL_JSON_PATH_ = "/usr/share/stf_tools/mavis";
+        const auto share_relative_path = exe_dir / SHARE_RELATIVE_JSON_PATH_;
 
-    if (fs::exists(STF_SHARE_GLOBAL_JSON_PATH_))
-    {
-        return std::string(STF_SHARE_GLOBAL_JSON_PATH_);
-    }
+        if (fs::exists(share_relative_path))
+        {
+            return share_relative_path;
+        }
+
+        static constexpr std::string_view SHARE_GLOBAL_JSON_PATH_ = "/usr/share/mavis_tools/mavis";
+
+        if (fs::exists(SHARE_GLOBAL_JSON_PATH_))
+        {
+            return SHARE_GLOBAL_JSON_PATH_;
+        }
+
+        // Check for an existing stf_tools install if there isn't a global mavis_tools install
+        static constexpr std::string_view STF_SHARE_RELATIVE_JSON_PATH_ =
+            "../share/stf_tools/mavis";
+
+        const auto stf_share_relative_path = exe_dir / STF_SHARE_RELATIVE_JSON_PATH_;
+
+        if (fs::exists(stf_share_relative_path))
+        {
+            return share_relative_path;
+        }
+
+        static constexpr std::string_view STF_SHARE_GLOBAL_JSON_PATH_ =
+            "/usr/share/stf_tools/mavis";
+
+        if (fs::exists(STF_SHARE_GLOBAL_JSON_PATH_))
+        {
+            return STF_SHARE_GLOBAL_JSON_PATH_;
+        }
 
 #ifdef MAVIS_GLOBAL_PATH
-    static constexpr std::string_view DEFAULT_GLOBAL_JSON_PATH_ =
-        MAVIS_GLOBAL_PATH; /**< Default path to globally installed Mavis JSON files*/
+        static constexpr std::string_view DEFAULT_GLOBAL_JSON_PATH_ =
+            MAVIS_GLOBAL_PATH; /**< Default path to globally installed Mavis JSON files*/
 
-    if (fs::exists(DEFAULT_GLOBAL_JSON_PATH_))
-    {
-        return std::string(DEFAULT_GLOBAL_JSON_PATH_);
-    }
+        if (fs::exists(DEFAULT_GLOBAL_JSON_PATH_))
+        {
+            return DEFAULT_GLOBAL_JSON_PATH_;
+        }
 #endif
 
-    throw CouldNotFindMavisException();
-}
+        throw CouldNotFindMavisException();
+    }
 
-inline std::pair<std::string, std::string>
-getRISCVJSONInfo(const std::string & mavis_path = getMavisPath())
-{
-    static const std::string isa_json = "/riscv_isa_spec.json";
-    const std::string json_path = mavis_path + "/json";
-    return std::make_pair(json_path, json_path + isa_json);
-}
+    inline std::pair<fs::path, fs::path>
+    getRISCVJSONInfo(const fs::path & mavis_path = getMavisPath())
+    {
+        static constexpr std::string_view isa_json = "riscv_isa_spec.json";
+        const fs::path json_path = mavis_path / "json";
+        return std::make_pair(json_path, json_path / isa_json);
+    }
+} // namespace mavis_tools

--- a/include/mavis_tool_exceptions.hpp
+++ b/include/mavis_tool_exceptions.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <exception>
+#include <string>
+
+namespace mavis_tools
+{
+    class MavisToolException : public std::exception
+    {
+      protected:
+        const std::string msg_;
+
+      public:
+        MavisToolException() = default;
+
+        explicit MavisToolException(std::string && msg) : msg_(std::move(msg)) {}
+
+        const char* what() const noexcept override final { return msg_.c_str(); }
+    };
+
+    class CommandLineException : public MavisToolException
+    {
+      private:
+        const int return_code_;
+
+      public:
+        explicit CommandLineException(const int return_code = 0) :
+            MavisToolException(),
+            return_code_(return_code)
+        {
+        }
+
+        explicit CommandLineException(std::string && msg, const int return_code = 1) :
+            MavisToolException(std::forward<std::string>(msg)),
+            return_code_(return_code)
+        {
+        }
+
+        bool hasMessage() const { return !msg_.empty(); }
+
+        int getReturnCode() const { return return_code_; }
+    };
+} // namespace mavis_tools

--- a/include/mnemonic_extension_map.hpp
+++ b/include/mnemonic_extension_map.hpp
@@ -1,15 +1,51 @@
 #pragma once
 
 #include "mavis/ExtensionManager.hpp"
+#include "constants.hpp"
+#include "json_key.hpp"
 
 namespace mavis_tools
 {
     // Maps mnemonics to the extensions that enable them
     class MnemonicExtensionMap
     {
+      public:
+        class Mnemonic
+        {
+          private:
+            std::string parent_;
+            std::vector<std::vector<std::string>> enabling_extensions_;
+
+          public:
+            Mnemonic(const std::string & mnemonic,
+                     const std::vector<std::vector<std::string>> & enabling_extensions) :
+                parent_(mnemonic),
+                enabling_extensions_(enabling_extensions)
+            {
+            }
+
+            void setParent(const boost::json::string & parent) { parent_ = parent.c_str(); }
+
+            const std::string & dealias() const { return parent_; }
+
+            const std::vector<std::vector<std::string>> & getExtensions() const
+            {
+                return enabling_extensions_;
+            }
+
+            // auto operator<=>(const Mnemonic & rhs) const
+            //{
+            //     return std::string_view(mnemonic_) <=> std::string_view(rhs.mnemonic_);
+            // }
+
+            // bool operator==(const Mnemonic & rhs) const { return mnemonic_ == rhs.mnemonic_; }
+        };
+
       private:
-        std::map<std::string, std::vector<std::vector<std::string>>> mnemonic_map_;
-        mutable std::vector<std::string> mnemonics_;
+        using MnemonicMap = std::map<std::string, Mnemonic>;
+
+        JSONKey mnemonic_key_{MNEMONIC_KEY};
+        MnemonicMap mnemonic_map_;
 
       public:
         // Requires a fully-specified ExtensionManager instance (i.e., the ISA string has been set
@@ -31,40 +67,48 @@ namespace mavis_tools
 
                     for (const auto & inst_info : jobj)
                     {
-                        const auto mnemonic = boost::json::value_to<std::string>(
-                            inst_info.as_object().at("mnemonic"));
+                        const auto & inst_obj = inst_info.as_object();
+                        const auto mnemonic =
+                            boost::json::value_to<std::string>(inst_obj.at(mnemonic_key_.getKey()));
 
-                        if (ext->isInternalOnly())
-                        {
-                            mnemonic_map_[mnemonic] = ext_man.getEnablingExtensions(ext);
-                        }
+                        mnemonic_key_.updateWidth(mnemonic);
 
-                        else
+                        auto & mnemonic_info =
+                            mnemonic_map_
+                                .try_emplace(mnemonic, mnemonic,
+                                             ext->isInternalOnly()
+                                                 ? ext_man.getEnablingExtensions(ext)
+                                                 : std::vector<std::vector<std::string>>{{name}})
+                                .first->second;
+
+                        if (const auto it = inst_obj.find("expand"); it != inst_obj.end())
                         {
-                            mnemonic_map_[mnemonic] = {{name}};
+                            mnemonic_info.setParent(it->value().as_string());
                         }
                     }
                 }
             }
         }
 
-        const std::vector<std::string> & getMnemonics() const
-        {
-            if (mnemonics_.empty()) [[unlikely]]
-            {
-                for (const auto & [mnemonic, _] : mnemonic_map_)
-                {
-                    mnemonics_.emplace_back(mnemonic);
-                }
-            }
+        const JSONKey & getKey() const { return mnemonic_key_; }
 
-            return mnemonics_;
-        }
+        const auto & getMnemonics() const { return mnemonic_map_; }
 
         const std::vector<std::vector<std::string>> &
         getExtensions(const std::string & mnemonic) const
         {
-            return mnemonic_map_.at(mnemonic);
+            return mnemonic_map_.at(mnemonic).getExtensions();
+        }
+
+        friend inline std::ostream & operator<<(std::ostream & os,
+                                                const MnemonicExtensionMap & mnemonic_info)
+        {
+            for (const auto & [mnemonic, _] : mnemonic_info.getMnemonics())
+            {
+                os << mnemonic << std::endl;
+            }
+
+            return os;
         }
     };
 } // namespace mavis_tools

--- a/include/uarch_json.hpp
+++ b/include/uarch_json.hpp
@@ -1,0 +1,280 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <unordered_map>
+
+#include "command_line_param.hpp"
+#include "filesystem.hpp"
+#include "constants.hpp"
+#include "mavis_tool_exceptions.hpp"
+#include "json_key.hpp"
+
+namespace mavis_tools
+{
+    class NotAJSONFileException : public MavisToolException
+    {
+      public:
+        explicit NotAJSONFileException(const fs::path & path) :
+            MavisToolException(path.string() + " is not a JSON file")
+        {
+        }
+    };
+
+    class NotAJSONDirectoryException : public MavisToolException
+    {
+      public:
+        explicit NotAJSONDirectoryException(const fs::path & path) :
+            MavisToolException(path.string() + " is not a directory")
+        {
+        }
+    };
+
+    class MissingUArchInfoException : public MavisToolException
+    {
+      public:
+        explicit MissingUArchInfoException(const boost::json::string & mnemonic) :
+            MissingUArchInfoException(std::string(mnemonic.c_str()))
+        {
+        }
+
+        explicit MissingUArchInfoException(const std::string & mnemonic) :
+            MavisToolException("Mnemonic " + mnemonic + " is not present in the uarch info")
+        {
+        }
+    };
+
+    class DuplicateUArchInfoException : public MavisToolException
+    {
+      public:
+        DuplicateUArchInfoException(const boost::json::string & mnemonic,
+                                    const fs::path & first_file, const fs::path & second_file) :
+            MavisToolException("Duplicate entries found for mnemonic "
+                               + std::string(mnemonic.c_str()) + " in files " + first_file.string()
+                               + " and " + second_file.string())
+        {
+        }
+    };
+
+    // Holds Mavis uarch JSON data
+    class UArchJSONInfo
+    {
+      private:
+        // Maps a single uarch JSON key to all of its per-mnemonic values
+        class UArchJSONEntry
+        {
+          private:
+            JSONKey key_;
+            std::unordered_map<std::string, boost::json::value> values_;
+
+          public:
+            class Ref
+            {
+              private:
+                const JSONKey & key_;
+                const boost::json::value & value_;
+
+              public:
+                Ref(const JSONKey & key, const boost::json::value & value) :
+                    key_(key),
+                    value_(value)
+                {
+                }
+
+                friend inline std::ostream & operator<<(std::ostream & os, const Ref & ref)
+                {
+                    ref.key_.formatColumn(os, ref.value_);
+                    return os;
+                }
+            };
+
+            UArchJSONEntry() = default;
+
+            explicit UArchJSONEntry(const JSONKey & key) : key_(key) {}
+
+            void update(const boost::json::string & mnemonic, const boost::json::object & json_obj)
+            {
+                const auto & key = key_.getKey();
+                const auto & value = json_obj.at(key);
+                values_[mnemonic.c_str()] = value;
+                key_.updateWidth(value);
+            }
+
+            const JSONKey & getKey() const { return key_; }
+
+            Ref get(const std::string & mnemonic) const
+            {
+                const auto it = values_.find(mnemonic);
+
+                if (__builtin_expect(it == values_.end(), 0))
+                {
+                    throw MissingUArchInfoException(mnemonic);
+                }
+
+                return Ref(key_, it->second);
+            }
+
+            friend inline std::istream & operator>>(std::istream & is, UArchJSONEntry & entry)
+            {
+                is >> entry.key_;
+                return is;
+            }
+        };
+
+        inline static constexpr CommandLineParam<std::vector<fs::path>> UARCH_JSON_PARAM_{
+            "uarch_json", 'j', true, "path(s) to uarch JSON(s)"};
+        inline static constexpr CommandLineParam<std::vector<fs::path>> UARCH_JSON_DIR_PARAM_{
+            "uarch_json_dir", 'J', "path to uarch JSON directory"};
+        inline static constexpr CommandLineParam<std::vector<UArchJSONEntry>> UARCH_JSON_KEY_PARAM_{
+            "uarch_json_key", 'k', "uarch JSON key(s)"};
+        inline static constexpr CommandLineParam<std::vector<std::string>>
+            JSON_INCLUDE_REGEX_PARAM_{"include",
+                                      "regex pattern(s) for files to include from JSON directory"};
+
+        std::vector<UArchJSONEntry> uarch_info_;
+
+      public:
+        explicit UArchJSONInfo(const boost::program_options::variables_map & vm) :
+            uarch_info_(UARCH_JSON_KEY_PARAM_.getValue(vm))
+        {
+            if (JSON_INCLUDE_REGEX_PARAM_.exists(vm) && !UARCH_JSON_DIR_PARAM_.exists(vm)
+                && !UARCH_JSON_PARAM_.exists(vm))
+            {
+                throw CommandLineException("--include argument requires at some uarch JSONs to be "
+                                           "specified with -J or -j");
+            }
+
+            if (!UARCH_JSON_KEY_PARAM_.exists(vm))
+            {
+                if (UARCH_JSON_PARAM_.exists(vm))
+                {
+                    throw CommandLineException(
+                        "-j argument requires at least one uarch JSON key to be specified with -k");
+                }
+                else if (UARCH_JSON_DIR_PARAM_.exists(vm))
+                {
+                    throw CommandLineException(
+                        "-J argument requires at least one uarch JSON key to be specified with -k");
+                }
+            }
+            else
+            {
+                const auto uarch_jsons = UARCH_JSON_PARAM_.getValue(vm);
+                const auto uarch_json_dirs = UARCH_JSON_DIR_PARAM_.getValue(vm);
+                const auto json_include_regex =
+                    JSON_INCLUDE_REGEX_PARAM_.getValue<std::vector<std::regex>>(vm);
+
+                const auto canonicalize = [](const fs::path & path) { return fs::canonical(path); };
+
+                std::set<fs::path> json_results;
+
+                const auto append_json =
+                    [&json_include_regex, &json_results, &canonicalize](const fs::path & uarch_json)
+                {
+                    const auto is_json = [](const fs::path & abs_path)
+                    { return fs::is_regular_file(abs_path) && abs_path.extension() == ".json"; };
+
+                    const auto is_included = [&json_include_regex](const fs::path & abs_path)
+                    {
+                        if (json_include_regex.empty())
+                        {
+                            return true;
+                        }
+                        const auto filename = abs_path.filename();
+                        const auto & filename_str = filename.native();
+                        return std::any_of(json_include_regex.begin(), json_include_regex.end(),
+                                           [&filename_str](const auto & regex)
+                                           { return std::regex_search(filename_str, regex); });
+                    };
+
+                    if (is_included(uarch_json))
+                    {
+                        const auto canonicalized_json = canonicalize(uarch_json);
+
+                        if (!is_json(canonicalized_json))
+                        {
+                            throw NotAJSONFileException(uarch_json);
+                        }
+
+                        json_results.emplace(canonicalized_json);
+                    }
+                };
+
+                for (const auto & uarch_json : uarch_jsons)
+                {
+                    append_json(uarch_json);
+                }
+
+                for (const auto & uarch_json_dir : uarch_json_dirs)
+                {
+                    const auto & abs_path = canonicalize(uarch_json_dir);
+
+                    if (!fs::is_directory(abs_path))
+                    {
+                        throw NotAJSONDirectoryException(uarch_json_dir);
+                    }
+
+                    for (const auto & uarch_json : fs::directory_iterator{abs_path})
+                    {
+                        append_json(uarch_json);
+                    }
+                }
+
+                if (json_results.empty())
+                {
+                    throw CommandLineException(
+                        "-k argument requires at least one uarch JSON to be specified with -j/-J");
+                }
+
+                std::unordered_map<boost::json::string, std::set<fs::path>::const_iterator>
+                    mnemonic_to_json_map;
+
+                for (auto it = json_results.begin(); it != json_results.end(); ++it)
+                {
+                    const auto & uarch_json = *it;
+                    const auto json_value = mavis::parseJSON(uarch_json);
+                    for (const auto & elem : json_value.as_array())
+                    {
+                        const auto & json_obj = elem.as_object();
+                        const auto & mnemonic = json_obj.at(MNEMONIC_KEY).as_string();
+                        const auto dup_check_result =
+                            mnemonic_to_json_map.try_emplace(mnemonic, it);
+                        if (!dup_check_result.second)
+                        {
+                            throw DuplicateUArchInfoException(
+                                mnemonic, *dup_check_result.first->second, uarch_json);
+                        }
+
+                        for (auto & info : uarch_info_)
+                        {
+                            info.update(mnemonic, json_obj);
+                        }
+                    }
+                }
+            }
+        }
+
+        bool empty() const { return uarch_info_.empty(); }
+
+        void formatKeys(std::ostream & os) const
+        {
+            for (const auto & info : uarch_info_)
+            {
+                os << info.getKey();
+            }
+        }
+
+        auto begin() const { return uarch_info_.begin(); }
+
+        auto end() const { return uarch_info_.end(); }
+
+        inline static constexpr void
+        addOptions(boost::program_options::options_description & optional_args)
+        {
+            UARCH_JSON_PARAM_.addOption(optional_args);
+            UARCH_JSON_DIR_PARAM_.addOption(optional_args);
+            JSON_INCLUDE_REGEX_PARAM_.addOption(optional_args);
+            UARCH_JSON_KEY_PARAM_.addOption(optional_args);
+        }
+    };
+} // namespace mavis_tools

--- a/tools/identify_opcode/main.cpp
+++ b/tools/identify_opcode/main.cpp
@@ -1,3 +1,4 @@
+#include <format>
 #include <iostream>
 #include <iomanip>
 #include <set>
@@ -7,28 +8,43 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include "mavis/extension_managers/RISCVExtensionManager.hpp"
+#include "command_line_param.hpp"
 #include "mavis_path.hpp"
 #include "mnemonic_extension_map.hpp"
 #include "maximal_isa_string_generator.hpp"
 #include "mavis_types.hpp"
+#include "mavis_tool_exceptions.hpp"
+
+class UnknownOpcodeException : public mavis_tools::MavisToolException
+{
+  public:
+    explicit UnknownOpcodeException(const uint32_t opcode) :
+        MavisToolException(std::format("{:x} is an unknown opcode", opcode))
+    {
+    }
+};
+
+class IllegalOpcodeException : public mavis_tools::MavisToolException
+{
+  public:
+    explicit IllegalOpcodeException(const uint32_t opcode) :
+        MavisToolException(std::format("{:x} is an illegal opcode", opcode))
+    {
+    }
+};
 
 int main(int argc, char* argv[])
 {
     static const std::vector<uint32_t> ALLOWED_XLENS{32, 64};
 
-    std::string mavis_path;
+    fs::path mavis_path;
     std::string opcode_str;
     std::vector<uint32_t> xlens;
 
-    boost::program_options::options_description optional_args("Optional arguments");
+    auto optional_args = mavis_tools::getDefaultOptionalArgs(mavis_path);
     boost::program_options::options_description required_args("Required arguments");
 
-    optional_args.add_options()("help,h", "print this help message")(
-        "mavis,m",
-        boost::program_options::value<std::string>(&mavis_path)
-            ->default_value(getMavisPath())
-            ->value_name("path"),
-        "path to mavis")(
+    optional_args.add_options()(
         "xlen,x",
         boost::program_options::value<std::vector<uint32_t>>(&xlens)->composing()->value_name("xn"),
         "restrict search to given XLEN(s)");
@@ -51,8 +67,186 @@ int main(int argc, char* argv[])
                                   vm);
     boost::program_options::notify(vm);
 
-    const auto print_help = [&optional_args]()
+    try
     {
+        if (vm.count("help") != 0)
+        {
+            throw mavis_tools::CommandLineException();
+        }
+
+        if (vm.count("opcode") == 0)
+        {
+            throw mavis_tools::CommandLineException("Opcode must be specified");
+        }
+
+        if (xlens.empty())
+        {
+            xlens = ALLOWED_XLENS;
+        }
+        else
+        {
+            for (const auto xlen : xlens)
+            {
+                if (std::find(ALLOWED_XLENS.begin(), ALLOWED_XLENS.end(), xlen)
+                    == ALLOWED_XLENS.end())
+                {
+                    std::ostringstream os;
+                    os << "Invalid XLEN specified: " << xlen << std::endl
+                       << "Allowed XLENs:" << std::endl;
+
+                    for (const auto allowed_xlen : ALLOWED_XLENS)
+                    {
+                        os << "- " << allowed_xlen << std::endl;
+                    }
+
+                    throw mavis_tools::CommandLineException(os.str());
+                }
+            }
+        }
+
+        const auto [json_path, isa_spec_json] = mavis_tools::getRISCVJSONInfo(mavis_path);
+
+        const uint32_t opcode = std::stoul(opcode_str, nullptr, 16);
+
+        auto ext_manager = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON(
+            isa_spec_json, json_path);
+        const mavis_tools::MaximalISAStringGenerator isa_string_gen(ext_manager, xlens);
+
+        // Maps XLEN -> mnemonic -> formatted string of extension / combination(s) of extensions
+        // that enable the mnemonic Using an std::set ensures we don't get any duplicates
+        std::map<uint32_t, std::map<std::string, std::set<std::string>>> found_mnemonics;
+        bool is_unknown = false;
+        bool is_illegal = false;
+
+        for (const auto xlen : xlens)
+        {
+            auto & xlen_found_mnemonics = found_mnemonics[xlen];
+
+            for (const auto & isa_string : isa_string_gen.getISAStrings(xlen))
+            {
+                ext_manager.setISA(isa_string);
+                auto mavis = ext_manager.constructMavis<mavis_tools::StubInstType,
+                                                        mavis_tools::StubAnnotationType>({});
+
+                try
+                {
+                    const auto decode_info = mavis.getInfo(opcode);
+                    const auto & mnemonic = decode_info->opinfo->getMnemonic();
+
+                    const mavis_tools::MnemonicExtensionMap ext_map(ext_manager);
+                    const auto & extensions = ext_map.getExtensions(mnemonic);
+
+                    if (extensions.empty()) [[unlikely]]
+                    {
+                        throw std::runtime_error("Could not find extension for " + mnemonic);
+                    }
+
+                    xlen_found_mnemonics[mnemonic].emplace(
+                        [&extensions]
+                        {
+                            const bool multiple_terms = extensions.size() > 1;
+
+                            // For mnemonics enabled by a single extension, just return the name of
+                            // the extension
+                            if (!multiple_terms && extensions.front().size() == 1)
+                            {
+                                return extensions.front().front();
+                            }
+
+                            std::ostringstream os;
+
+                            // For mnemonics that are enabled by multiple extensions, or only
+                            // enabled if multiple extensions are present, generate a logical
+                            // expression
+                            bool first_outer = true;
+                            for (const auto & ext_combination : extensions)
+                            {
+                                if (first_outer)
+                                {
+                                    first_outer = false;
+                                }
+                                else
+                                {
+                                    // The outer vector specifies ORed terms
+                                    os << " || ";
+                                }
+
+                                const bool multiple_inner_terms =
+                                    multiple_terms && ext_combination.size() > 1;
+
+                                if (multiple_inner_terms)
+                                {
+                                    os << '(';
+                                }
+
+                                bool first_inner = true;
+                                for (const auto & ext : ext_combination)
+                                {
+                                    if (first_inner)
+                                    {
+                                        first_inner = false;
+                                    }
+                                    else
+                                    {
+                                        // The inner vector specifies ANDed terms
+                                        os << " && ";
+                                    }
+                                    os << ext;
+                                }
+
+                                if (multiple_inner_terms)
+                                {
+                                    os << ')';
+                                }
+                            }
+
+                            return os.str();
+                        }());
+                }
+                catch (const mavis::UnknownOpcode &)
+                {
+                    is_unknown = true;
+                }
+                catch (const mavis::IllegalOpcode &)
+                {
+                    is_illegal = true;
+                }
+            }
+        }
+
+        if (!found_mnemonics.empty())
+        {
+            std::cout << "Candidates:" << std::endl;
+
+            for (const auto & [xlen, mnemonic_info] : found_mnemonics)
+            {
+                for (const auto & [mnemonic, all_extensions] : mnemonic_info)
+                {
+                    for (const auto & extensions : all_extensions)
+                    {
+                        std::cout << "- xlen: " << xlen << std::endl
+                                  << "  mnemonic: " << mnemonic << std::endl
+                                  << "  extension: " << extensions << std::endl;
+                    }
+                }
+            }
+        }
+        else if (is_unknown)
+        {
+            throw UnknownOpcodeException(opcode);
+        }
+        else if (is_illegal)
+        {
+            throw IllegalOpcodeException(opcode);
+        }
+    }
+    catch (const mavis_tools::CommandLineException & ex)
+    {
+        if (ex.hasMessage())
+        {
+            std::cerr << ex.what() << std::endl;
+        }
+
         std::ios init(NULL);
         init.copyfmt(std::cerr);
         std::cerr << "Usage: identify_opcode [OPTION] <opcode>" << std::endl
@@ -64,180 +258,12 @@ int main(int argc, char* argv[])
                   << "  <opcode>";
         std::cerr.copyfmt(init);
         std::cerr << "opcode to find" << std::endl;
-    };
 
-    if (vm.count("help") != 0)
-    {
-        print_help();
-        return 0;
+        return ex.getReturnCode();
     }
-
-    if (vm.count("opcode") == 0)
+    catch (const mavis_tools::MavisToolException & ex)
     {
-        std::cerr << "Opcode must be specified" << std::endl;
-        print_help();
-        return 1;
-    }
-
-    if (xlens.empty())
-    {
-        xlens = ALLOWED_XLENS;
-    }
-    else
-    {
-        for (const auto xlen : xlens)
-        {
-            if (std::find(ALLOWED_XLENS.begin(), ALLOWED_XLENS.end(), xlen) == ALLOWED_XLENS.end())
-            {
-                std::cerr << "Invalid XLEN specified: " << xlen << std::endl
-                          << "Allowed XLENs:" << std::endl;
-
-                for (const auto allowed_xlen : ALLOWED_XLENS)
-                {
-                    std::cerr << "- " << allowed_xlen << std::endl;
-                }
-
-                print_help();
-                return 1;
-            }
-        }
-    }
-
-    const auto [json_path, isa_spec_json] = getRISCVJSONInfo(mavis_path);
-
-    const uint32_t opcode = std::stoul(opcode_str, nullptr, 16);
-
-    auto ext_manager = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON(
-        isa_spec_json, json_path);
-    const mavis_tools::MaximalISAStringGenerator isa_string_gen(ext_manager, xlens);
-
-    // Maps XLEN -> mnemonic -> formatted string of extension / combination(s) of extensions that
-    // enable the mnemonic
-    // Using an std::set ensures we don't get any duplicates
-    std::map<uint32_t, std::map<std::string, std::set<std::string>>> found_mnemonics;
-    bool is_unknown = false;
-    bool is_illegal = false;
-
-    for (const auto xlen : xlens)
-    {
-        auto & xlen_found_mnemonics = found_mnemonics[xlen];
-
-        for (const auto & isa_string : isa_string_gen.getISAStrings(xlen))
-        {
-            ext_manager.setISA(isa_string);
-            auto mavis =
-                ext_manager
-                    .constructMavis<mavis_tools::StubInstType, mavis_tools::StubAnnotationType>({});
-
-            try
-            {
-                const auto decode_info = mavis.getInfo(opcode);
-                const auto & mnemonic = decode_info->opinfo->getMnemonic();
-
-                const mavis_tools::MnemonicExtensionMap ext_map(ext_manager);
-                const auto & extensions = ext_map.getExtensions(mnemonic);
-
-                if (extensions.empty()) [[unlikely]]
-                {
-                    throw std::runtime_error("Could not find extension for " + mnemonic);
-                }
-
-                xlen_found_mnemonics[mnemonic].emplace(
-                    [&extensions]
-                    {
-                        const bool multiple_terms = extensions.size() > 1;
-
-                        // For mnemonics enabled by a single extension, just return the name of the
-                        // extension
-                        if (!multiple_terms && extensions.front().size() == 1)
-                        {
-                            return extensions.front().front();
-                        }
-
-                        std::ostringstream os;
-
-                        // For mnemonics that are enabled by multiple extensions, or only enabled if
-                        // multiple extensions are present, generate a logical expression
-                        bool first_outer = true;
-                        for (const auto & ext_combination : extensions)
-                        {
-                            if (first_outer)
-                            {
-                                first_outer = false;
-                            }
-                            else
-                            {
-                                // The outer vector specifies ORed terms
-                                os << " || ";
-                            }
-
-                            const bool multiple_inner_terms =
-                                multiple_terms && ext_combination.size() > 1;
-
-                            if (multiple_inner_terms)
-                            {
-                                os << '(';
-                            }
-
-                            bool first_inner = true;
-                            for (const auto & ext : ext_combination)
-                            {
-                                if (first_inner)
-                                {
-                                    first_inner = false;
-                                }
-                                else
-                                {
-                                    // The inner vector specifies ANDed terms
-                                    os << " && ";
-                                }
-                                os << ext;
-                            }
-
-                            if (multiple_inner_terms)
-                            {
-                                os << ')';
-                            }
-                        }
-
-                        return os.str();
-                    }());
-            }
-            catch (const mavis::UnknownOpcode &)
-            {
-                is_unknown = true;
-            }
-            catch (const mavis::IllegalOpcode &)
-            {
-                is_illegal = true;
-            }
-        }
-    }
-
-    if (!found_mnemonics.empty())
-    {
-        std::cout << "Candidates:" << std::endl;
-
-        for (const auto & [xlen, mnemonic_info] : found_mnemonics)
-        {
-            for (const auto & [mnemonic, all_extensions] : mnemonic_info)
-            {
-                for (const auto & extensions : all_extensions)
-                {
-                    std::cout << "- xlen: " << xlen << std::endl
-                              << "  mnemonic: " << mnemonic << std::endl
-                              << "  extension: " << extensions << std::endl;
-                }
-            }
-        }
-    }
-    else if (is_unknown)
-    {
-        std::cerr << std::hex << opcode << " is an unknown opcode" << std::endl;
-    }
-    else if (is_illegal)
-    {
-        std::cerr << std::hex << opcode << " is an illegal opcode" << std::endl;
+        std::cerr << ex.what() << std::endl;
         return 1;
     }
 

--- a/tools/isa_dump/main.cpp
+++ b/tools/isa_dump/main.cpp
@@ -4,23 +4,20 @@
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
 #include "mavis/extension_managers/RISCVExtensionManager.hpp"
+#include "filesystem.hpp"
 #include "mavis_path.hpp"
 #include "mnemonic_extension_map.hpp"
+#include "uarch_json.hpp"
 
 int main(int argc, char* argv[])
 {
-    std::string mavis_path;
+    fs::path mavis_path;
     std::string isa_string;
 
-    boost::program_options::options_description optional_args("Optional arguments");
+    auto optional_args = mavis_tools::getDefaultOptionalArgs(mavis_path);
     boost::program_options::options_description required_args("Required arguments");
 
-    optional_args.add_options()("help,h", "print this help message")(
-        "mavis,m",
-        boost::program_options::value<std::string>(&mavis_path)
-            ->default_value(getMavisPath())
-            ->value_name("path"),
-        "path to mavis");
+    mavis_tools::UArchJSONInfo::addOptions(optional_args);
 
     required_args.add_options()("isa-string",
                                 boost::program_options::value<std::string>(&isa_string),
@@ -41,11 +38,63 @@ int main(int argc, char* argv[])
                                   vm);
     boost::program_options::notify(vm);
 
-    const auto print_help = [&optional_args]()
+    try
     {
+        if (vm.count("help") != 0)
+        {
+            throw mavis_tools::CommandLineException();
+        }
+
+        if (vm.count("isa-string") == 0)
+        {
+            throw mavis_tools::CommandLineException("ISA string must be specified");
+        }
+
+        const auto [json_path, isa_spec_json] = mavis_tools::getRISCVJSONInfo(mavis_path);
+
+        mavis_tools::MnemonicExtensionMap mnemonic_info(
+            mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(
+                isa_string, isa_spec_json, json_path));
+
+        const mavis_tools::UArchJSONInfo uarch_info(vm);
+
+        if (uarch_info.empty())
+        {
+            std::cout << mnemonic_info;
+        }
+        else
+        {
+            const auto & mnemonic_key = mnemonic_info.getKey();
+
+            std::cout << mnemonic_key;
+
+            uarch_info.formatKeys(std::cout);
+
+            std::cout << std::endl;
+
+            for (const auto & [mnemonic, mnemonic_info] : mnemonic_info.getMnemonics())
+            {
+                mnemonic_key.formatColumn(std::cout, mnemonic);
+
+                for (const auto & info : uarch_info)
+                {
+                    std::cout << info.get(mnemonic_info.dealias());
+                }
+
+                std::cout << std::endl;
+            }
+        }
+    }
+    catch (const mavis_tools::CommandLineException & ex)
+    {
+        if (ex.hasMessage())
+        {
+            std::cerr << ex.what() << std::endl;
+        }
+
         std::ios init(NULL);
         init.copyfmt(std::cerr);
-        std::cerr << "Usage: isa_dump [OPTION] <isa string>" << std::endl
+        std::cerr << "Usage: isa_dump [OPTION] [--] <isa string>" << std::endl
                   << "Dumps all instruction mnemonics enabled by the given ISA string" << std::endl
                   << std::endl
                   << optional_args << std::endl
@@ -54,30 +103,13 @@ int main(int argc, char* argv[])
                   << "  <isa string>";
         std::cerr.copyfmt(init);
         std::cerr << "RISC-V ISA string to dump" << std::endl;
-    };
 
-    if (vm.count("help") != 0)
-    {
-        print_help();
-        return 0;
+        return ex.getReturnCode();
     }
-
-    if (vm.count("isa-string") == 0)
+    catch (const mavis_tools::MavisToolException & ex)
     {
-        std::cerr << "ISA string must be specified" << std::endl;
-        print_help();
+        std::cerr << ex.what() << std::endl;
         return 1;
-    }
-
-    const auto [json_path, isa_spec_json] = getRISCVJSONInfo(mavis_path);
-
-    mavis_tools::MnemonicExtensionMap mnemonic_map(
-        mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(isa_string, isa_spec_json,
-                                                                        json_path));
-
-    for (const auto & mnemonic : mnemonic_map.getMnemonics())
-    {
-        std::cout << mnemonic << std::endl;
     }
 
     return 0;


### PR DESCRIPTION
Add new functionality to `isa_dump`:

```
Usage: isa_dump [OPTION] [--] <isa string>
Dumps all instruction mnemonics enabled by the given ISA string

Optional arguments:
  -h [ --help ]                         print this help message
  -m [ --mavis ] path (="/work/mavis_tools/release/tools/isa_dump/../../../mavis")
                                        path to mavis
  -j [ --uarch_json ] uarch_json        path(s) to uarch JSON(s)
  -J [ --uarch_json_dir ] uarch_json_dir
                                        path to uarch JSON directory
  --include include                     regex pattern(s) for files to include 
                                        from JSON directory
  -k [ --uarch_json_key ] uarch_json_key
                                        uarch JSON key(s)

Required arguments:
  <isa string>                          RISC-V ISA string to dump
```

The `uarch*` arguments enable uarch JSON dumping support, allowing the user to dump arbitrary uarch JSON fields corresponding to the instructions supported by the given ISA string.