### PR TITLE
Update to latest Mavis, add identify_opcode tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ add_subdirectory(mavis)
 
 add_subdirectory(tools)
 
+if(MAVIS_TOOLS_INSTALL_DIR)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mavis/json DESTINATION ${MAVIS_TOOLS_INSTALL_DIR}/../share/mavis_tools/mavis)
+endif()
+
 if(NOT CLANGFORMAT_EXECUTABLE)
   set(CLANGFORMAT_EXECUTABLE clang-format)
 endif()

--- a/include/mavis_path.hpp
+++ b/include/mavis_path.hpp
@@ -128,3 +128,11 @@ inline std::string getMavisPath()
 
     throw CouldNotFindMavisException();
 }
+
+inline std::pair<std::string, std::string>
+getRISCVJSONInfo(const std::string & mavis_path = getMavisPath())
+{
+    static const std::string isa_json = "/riscv_isa_spec.json";
+    const std::string json_path = mavis_path + "/json";
+    return std::make_pair(json_path, json_path + isa_json);
+}

--- a/include/mavis_types.hpp
+++ b/include/mavis_types.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <boost/json.hpp>
+
+namespace mavis_tools
+{
+    // Minimal InstType class for instantiating a Mavis instance
+    class StubInstType
+    {
+      public:
+        using PtrType = std::shared_ptr<StubInstType>;
+    };
+
+    // Minimal AnnotationType class for instantiating a Mavis instance
+    class StubAnnotationType
+    {
+      public:
+        using PtrType = std::shared_ptr<StubAnnotationType>;
+
+        StubAnnotationType() = default;
+
+        StubAnnotationType(const boost::json::object &) {}
+
+        void update(const boost::json::object &) {}
+
+        friend inline std::ostream & operator<<(std::ostream & os, const StubAnnotationType &)
+        {
+            return os;
+        }
+    };
+} // namespace mavis_tools

--- a/include/maximal_isa_string_generator.hpp
+++ b/include/maximal_isa_string_generator.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/graph/subgraph.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/sequential_vertex_coloring.hpp>
+
+#include "mavis/extension_managers/RISCVExtensionManager.hpp"
+
+namespace mavis_tools
+{
+    // Generates enough different ISA strings to fully cover all ISA extensions while accounting for
+    // conflicts. This is implemented as its own class in case we want to pre-generate the strings
+    // at build time in the future. Right now, this is fast enough to do at runtime.
+    class MaximalISAStringGenerator
+    {
+      private:
+        template <typename ExtensionInfo, typename ExtensionState, typename SkipExtensionCallback,
+                  typename GenBaseISAStringCallback, typename AppendExtensionCallback>
+        void generate_(
+            const mavis::extension_manager::ExtensionManager<ExtensionInfo, ExtensionState> & man,
+            const std::vector<uint32_t> & arches, SkipExtensionCallback && skip_extension,
+            GenBaseISAStringCallback && gen_base_isa_string,
+            AppendExtensionCallback && append_extension)
+        {
+            // Helper lambda to get a const property map from a non-const graph
+            const auto get_const_property_map =
+                []<typename PropertyType>(const PropertyType property,
+                                          const mavis::extension_manager::ConflictGraph & graph)
+            { return get(property, graph); };
+
+            isa_strings_.clear();
+
+            for (const auto arch_id : arches)
+            {
+                auto ext_graph = man.getConflictGraph(arch_id);
+
+                // Divide the graph into two subgraphs:
+                // 1. Extensions that have no conflicts - these can always be part of the ISA string
+                // 2. Extensions that have at least 1 conflict - these need to be in separate ISA
+                // strings
+                mavis::extension_manager::ConflictGraph & always_enabled_extensions =
+                    ext_graph.create_subgraph();
+                mavis::extension_manager::ConflictGraph & conflicting_extensions =
+                    ext_graph.create_subgraph();
+
+                for (auto [it, end] = boost::vertices(ext_graph); it != end; ++it)
+                {
+                    const auto vertex = *it;
+                    if (boost::degree(vertex, ext_graph) != 0)
+                    {
+                        boost::add_vertex(vertex, conflicting_extensions);
+                    }
+                    else
+                    {
+                        boost::add_vertex(vertex, always_enabled_extensions);
+                    }
+                }
+
+                // If there are no conflicts, there is only 1 color needed
+                size_t num_colors = 1;
+
+                std::vector<mavis::extension_manager::ConflictGraph::vertices_size_type> color_vec;
+
+                if (const auto num_conflicts = boost::num_vertices(conflicting_extensions);
+                    num_conflicts != 0)
+                {
+                    // Create a color entry for every vertex in the conflict graph
+                    color_vec.resize(num_conflicts);
+                    const auto color = boost::make_iterator_property_map(
+                        color_vec.begin(),
+                        get_const_property_map(boost::vertex_index, conflicting_extensions));
+
+                    // Perform a simple graph coloring. Each conflicting extension will be assigned
+                    // a different color. Each color corresponds to a unique ISA string.
+                    num_colors = boost::sequential_vertex_coloring(conflicting_extensions, color);
+                }
+
+                std::string base_isa_string = gen_base_isa_string(arch_id);
+
+                const auto name_props =
+                    get_const_property_map(boost::vertex_name, always_enabled_extensions);
+
+                for (auto [it, end] = boost::vertices(always_enabled_extensions); it != end; ++it)
+                {
+                    const auto & name = get(name_props, *it);
+
+                    if (skip_extension(name))
+                    {
+                        continue;
+                    }
+
+                    append_extension(base_isa_string, name);
+                }
+
+                const auto emplace_result =
+                    isa_strings_.try_emplace(arch_id, num_colors, base_isa_string);
+                if (!emplace_result.second) [[unlikely]]
+                {
+                    throw std::runtime_error("Arch ID " + std::to_string(arch_id)
+                                             + " was given multiple times");
+                }
+
+                auto & isa_strings = emplace_result.first->second;
+
+                const auto conflict_name_props =
+                    get_const_property_map(boost::vertex_name, conflicting_extensions);
+
+                for (uint32_t i = 0; i < color_vec.size(); ++i)
+                {
+                    append_extension(
+                        isa_strings[color_vec[i]],
+                        get(conflict_name_props, boost::vertex(i, conflicting_extensions)));
+                }
+            }
+        }
+
+        std::map<uint32_t, std::vector<std::string>> isa_strings_;
+
+      public:
+        // Requires an extension manager that has at least had its ISA specification set with
+        // setISASpecJSON
+        MaximalISAStringGenerator(
+            const mavis::extension_manager::riscv::RISCVExtensionManager & man,
+            const std::vector<uint32_t> & arches)
+        {
+            generate_(
+                man, arches, [](const std::string & ext) { return ext == "i"; },
+                [](const uint32_t xlen) { return "rv" + std::to_string(xlen) + "i"; },
+                [](std::string & isa_string, const std::string & ext) { isa_string += '_' + ext; });
+        }
+
+        const std::vector<std::string> & getISAStrings(const uint32_t arch_id) const
+        {
+            return isa_strings_.at(arch_id);
+        }
+    };
+} // namespace mavis_tools

--- a/include/mnemonic_extension_map.hpp
+++ b/include/mnemonic_extension_map.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "mavis/ExtensionManager.hpp"
+
+namespace mavis_tools
+{
+    // Maps mnemonics to the extensions that enable them
+    class MnemonicExtensionMap
+    {
+      private:
+        std::map<std::string, std::vector<std::vector<std::string>>> mnemonic_map_;
+        mutable std::vector<std::string> mnemonics_;
+
+      public:
+        // Requires a fully-specified ExtensionManager instance (i.e., the ISA string has been set
+        // with setISA)
+        template <typename ExtensionInfo, typename ExtensionState>
+        explicit MnemonicExtensionMap(
+            const mavis::extension_manager::ExtensionManager<ExtensionInfo, ExtensionState> &
+                ext_man)
+        {
+            const auto & json_dir = ext_man.getMavisJSONDir();
+            const auto extensions = ext_man.getEnabledExtensions(true, true);
+
+            for (const auto & [name, ext] : extensions)
+            {
+                if (const auto & json = ext->getJSON(); !json.empty())
+                {
+                    const auto json_value = mavis::parseJSON(json_dir + "/" + json);
+                    const auto & jobj = json_value.as_array();
+
+                    for (const auto & inst_info : jobj)
+                    {
+                        const auto mnemonic = boost::json::value_to<std::string>(
+                            inst_info.as_object().at("mnemonic"));
+
+                        if (ext->isInternalOnly())
+                        {
+                            mnemonic_map_[mnemonic] = ext_man.getEnablingExtensions(ext);
+                        }
+
+                        else
+                        {
+                            mnemonic_map_[mnemonic] = {{name}};
+                        }
+                    }
+                }
+            }
+        }
+
+        const std::vector<std::string> & getMnemonics() const
+        {
+            if (mnemonics_.empty()) [[unlikely]]
+            {
+                for (const auto & [mnemonic, _] : mnemonic_map_)
+                {
+                    mnemonics_.emplace_back(mnemonic);
+                }
+            }
+
+            return mnemonics_;
+        }
+
+        const std::vector<std::vector<std::string>> &
+        getExtensions(const std::string & mnemonic) const
+        {
+            return mnemonic_map_.at(mnemonic);
+        }
+    };
+} // namespace mavis_tools

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_subdirectory(isa_dump)
+add_subdirectory(identify_opcode)
 
 set(MAVIS_TOOLS_INSTALL_TARGETS
     isa_dump
+    identify_opcode
 )
 
 include(mavis_extra_tools.cmake OPTIONAL)

--- a/tools/identify_opcode/CMakeLists.txt
+++ b/tools/identify_opcode/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(identify_opcode)
+add_executable(identify_opcode main.cpp)
+target_link_libraries (identify_opcode mavis Boost::program_options Boost::json)

--- a/tools/identify_opcode/README.md
+++ b/tools/identify_opcode/README.md
@@ -1,0 +1,17 @@
+# RISC-V Opcode Identification Utility
+
+Identifies all possible instructions (and the extensions that contain them) that map to a given opcode
+
+## Usage
+```
+Usage: identify_opcode [OPTION] <opcode>
+Identifies all RISC-V instructions that map to the given opcode
+
+Optional arguments:
+  -h [ --help ]                         print this help message
+  -m [ --mavis ] path (=mavis)          path to mavis
+  -x [ --xlen ] xn                      restrict search to given XLEN(s)
+
+Required arguments:
+  <opcode>                              opcode to find
+```

--- a/tools/identify_opcode/main.cpp
+++ b/tools/identify_opcode/main.cpp
@@ -1,0 +1,245 @@
+#include <iostream>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include "mavis/extension_managers/RISCVExtensionManager.hpp"
+#include "mavis_path.hpp"
+#include "mnemonic_extension_map.hpp"
+#include "maximal_isa_string_generator.hpp"
+#include "mavis_types.hpp"
+
+int main(int argc, char* argv[])
+{
+    static const std::vector<uint32_t> ALLOWED_XLENS{32, 64};
+
+    std::string mavis_path;
+    std::string opcode_str;
+    std::vector<uint32_t> xlens;
+
+    boost::program_options::options_description optional_args("Optional arguments");
+    boost::program_options::options_description required_args("Required arguments");
+
+    optional_args.add_options()("help,h", "print this help message")(
+        "mavis,m",
+        boost::program_options::value<std::string>(&mavis_path)
+            ->default_value(getMavisPath())
+            ->value_name("path"),
+        "path to mavis")(
+        "xlen,x",
+        boost::program_options::value<std::vector<uint32_t>>(&xlens)->composing()->value_name("xn"),
+        "restrict search to given XLEN(s)");
+
+    required_args.add_options()("opcode", boost::program_options::value<std::string>(&opcode_str),
+                                "Opcode to find");
+
+    boost::program_options::positional_options_description p;
+    p.add("opcode", 1);
+
+    boost::program_options::options_description all_args("All arguments");
+    all_args.add(optional_args).add(required_args);
+
+    boost::program_options::variables_map vm;
+
+    boost::program_options::store(boost::program_options::command_line_parser(argc, argv)
+                                      .options(all_args)
+                                      .positional(p)
+                                      .run(),
+                                  vm);
+    boost::program_options::notify(vm);
+
+    const auto print_help = [&optional_args]()
+    {
+        std::ios init(NULL);
+        init.copyfmt(std::cerr);
+        std::cerr << "Usage: identify_opcode [OPTION] <opcode>" << std::endl
+                  << "Identifies all RISC-V instructions that map to the given opcode" << std::endl
+                  << std::endl
+                  << optional_args << std::endl
+                  << "Required arguments:" << std::endl
+                  << std::setw(optional_args.get_option_column_width()) << std::left
+                  << "  <opcode>";
+        std::cerr.copyfmt(init);
+        std::cerr << "opcode to find" << std::endl;
+    };
+
+    if (vm.count("help") != 0)
+    {
+        print_help();
+        return 0;
+    }
+
+    if (vm.count("opcode") == 0)
+    {
+        std::cerr << "Opcode must be specified" << std::endl;
+        print_help();
+        return 1;
+    }
+
+    if (xlens.empty())
+    {
+        xlens = ALLOWED_XLENS;
+    }
+    else
+    {
+        for (const auto xlen : xlens)
+        {
+            if (std::find(ALLOWED_XLENS.begin(), ALLOWED_XLENS.end(), xlen) == ALLOWED_XLENS.end())
+            {
+                std::cerr << "Invalid XLEN specified: " << xlen << std::endl
+                          << "Allowed XLENs:" << std::endl;
+
+                for (const auto allowed_xlen : ALLOWED_XLENS)
+                {
+                    std::cerr << "- " << allowed_xlen << std::endl;
+                }
+
+                print_help();
+                return 1;
+            }
+        }
+    }
+
+    const auto [json_path, isa_spec_json] = getRISCVJSONInfo(mavis_path);
+
+    const uint32_t opcode = std::stoul(opcode_str, nullptr, 16);
+
+    auto ext_manager = mavis::extension_manager::riscv::RISCVExtensionManager::fromISASpecJSON(
+        isa_spec_json, json_path);
+    const mavis_tools::MaximalISAStringGenerator isa_string_gen(ext_manager, xlens);
+
+    // Maps XLEN -> mnemonic -> formatted string of extension / combination(s) of extensions that
+    // enable the mnemonic
+    // Using an std::set ensures we don't get any duplicates
+    std::map<uint32_t, std::map<std::string, std::set<std::string>>> found_mnemonics;
+    bool is_unknown = false;
+    bool is_illegal = false;
+
+    for (const auto xlen : xlens)
+    {
+        auto & xlen_found_mnemonics = found_mnemonics[xlen];
+
+        for (const auto & isa_string : isa_string_gen.getISAStrings(xlen))
+        {
+            ext_manager.setISA(isa_string);
+            auto mavis =
+                ext_manager
+                    .constructMavis<mavis_tools::StubInstType, mavis_tools::StubAnnotationType>({});
+
+            try
+            {
+                const auto decode_info = mavis.getInfo(opcode);
+                const auto & mnemonic = decode_info->opinfo->getMnemonic();
+
+                const mavis_tools::MnemonicExtensionMap ext_map(ext_manager);
+                const auto & extensions = ext_map.getExtensions(mnemonic);
+
+                if (extensions.empty()) [[unlikely]]
+                {
+                    throw std::runtime_error("Could not find extension for " + mnemonic);
+                }
+
+                xlen_found_mnemonics[mnemonic].emplace(
+                    [&extensions]
+                    {
+                        const bool multiple_terms = extensions.size() > 1;
+
+                        // For mnemonics enabled by a single extension, just return the name of the
+                        // extension
+                        if (!multiple_terms && extensions.front().size() == 1)
+                        {
+                            return extensions.front().front();
+                        }
+
+                        std::ostringstream os;
+
+                        // For mnemonics that are enabled by multiple extensions, or only enabled if
+                        // multiple extensions are present, generate a logical expression
+                        bool first_outer = true;
+                        for (const auto & ext_combination : extensions)
+                        {
+                            if (first_outer)
+                            {
+                                first_outer = false;
+                            }
+                            else
+                            {
+                                // The outer vector specifies ORed terms
+                                os << " || ";
+                            }
+
+                            const bool multiple_inner_terms =
+                                multiple_terms && ext_combination.size() > 1;
+
+                            if (multiple_inner_terms)
+                            {
+                                os << '(';
+                            }
+
+                            bool first_inner = true;
+                            for (const auto & ext : ext_combination)
+                            {
+                                if (first_inner)
+                                {
+                                    first_inner = false;
+                                }
+                                else
+                                {
+                                    // The inner vector specifies ANDed terms
+                                    os << " && ";
+                                }
+                                os << ext;
+                            }
+
+                            if (multiple_inner_terms)
+                            {
+                                os << ')';
+                            }
+                        }
+
+                        return os.str();
+                    }());
+            }
+            catch (const mavis::UnknownOpcode &)
+            {
+                is_unknown = true;
+            }
+            catch (const mavis::IllegalOpcode &)
+            {
+                is_illegal = true;
+            }
+        }
+    }
+
+    if (!found_mnemonics.empty())
+    {
+        std::cout << "Candidates:" << std::endl;
+
+        for (const auto & [xlen, mnemonic_info] : found_mnemonics)
+        {
+            for (const auto & [mnemonic, all_extensions] : mnemonic_info)
+            {
+                for (const auto & extensions : all_extensions)
+                {
+                    std::cout << "- xlen: " << xlen << std::endl
+                              << "  mnemonic: " << mnemonic << std::endl
+                              << "  extension: " << extensions << std::endl;
+                }
+            }
+        }
+    }
+    else if (is_unknown)
+    {
+        std::cerr << std::hex << opcode << " is an unknown opcode" << std::endl;
+    }
+    else if (is_illegal)
+    {
+        std::cerr << std::hex << opcode << " is an illegal opcode" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/tools/isa_dump/main.cpp
+++ b/tools/isa_dump/main.cpp
@@ -1,13 +1,11 @@
-#include <algorithm>
-#include <boost/program_options/options_description.hpp>
 #include <iostream>
 #include <iomanip>
 #include <string>
-#include <vector>
 #include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
 #include "mavis/extension_managers/RISCVExtensionManager.hpp"
-#include "mavis/JSONUtils.hpp"
 #include "mavis_path.hpp"
+#include "mnemonic_extension_map.hpp"
 
 int main(int argc, char* argv[])
 {
@@ -71,29 +69,15 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    const std::string json_path = mavis_path + "/json";
+    const auto [json_path, isa_spec_json] = getRISCVJSONInfo(mavis_path);
 
-    const auto ext_man = mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(
-        isa_string, json_path + "/riscv_isa_spec.json", json_path);
-    const auto & jsons = ext_man.getJSONs();
+    mavis_tools::MnemonicExtensionMap mnemonic_map(
+        mavis::extension_manager::riscv::RISCVExtensionManager::fromISA(isa_string, isa_spec_json,
+                                                                        json_path));
 
-    std::vector<boost::json::string> mnemonics;
-
-    for (const auto & json : jsons)
+    for (const auto & mnemonic : mnemonic_map.getMnemonics())
     {
-        const auto json_value = mavis::parseJSON(json);
-        const auto & jobj = json_value.as_array();
-        mnemonics.reserve(mnemonics.size() + jobj.size());
-        std::transform(jobj.begin(), jobj.end(), std::back_inserter(mnemonics),
-                       [](const boost::json::value & inst_info)
-                       { return inst_info.as_object().at("mnemonic").as_string(); });
-    }
-
-    std::sort(mnemonics.begin(), mnemonics.end());
-
-    for (const auto & mnemonic : mnemonics)
-    {
-        std::cout << mnemonic.c_str() << std::endl;
+        std::cout << mnemonic << std::endl;
     }
 
     return 0;


### PR DESCRIPTION
Adds an `identify_opcode` tool that identifies which instructions could map to an opcode along with the extensions that enable them.